### PR TITLE
Quick and dirty fix for https://github.com/boundary/folsom/issues/30

### DIFF
--- a/src/folsom_metrics_history.erl
+++ b/src/folsom_metrics_history.erl
@@ -42,6 +42,7 @@
 new(Name) ->
     Tid = ets:new(history, ?ETSOPTS),
     ets:insert(?HISTORY_TABLE, {Name, #history{tid=Tid}}),
+    ets:give_away(Tid, whereis(folsom_sup), none),
     ok.
 
 update(Name, Size, Value) ->


### PR DESCRIPTION
A history will survive a process crash without incident since
it is owned by folsom_sup.  This will leave the rest of the folsom
ets tables in a consistent state (all are owned by folsom_sup).